### PR TITLE
Fix socialLinks field parsing

### DIFF
--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -53,7 +53,15 @@ router.get('/:username', (req, res) => {
     const stmt = db.prepare(
       'SELECT id, username, displayName, userType, avatar, bio, socialLinks, createdAt FROM users WHERE username = ?'
     );
-    const user = stmt.get(username);
+    const user = stmt.get(username) as any;
+
+    if (user && typeof user.socialLinks === 'string') {
+      try {
+        user.socialLinks = JSON.parse(user.socialLinks);
+      } catch {
+        user.socialLinks = undefined;
+      }
+    }
 
     if (!user) {
       return res.status(404).json({


### PR DESCRIPTION
## Summary
- parse `socialLinks` JSON when attaching user data in middleware
- parse `socialLinks` JSON in `GET /users/:username`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841167a39b483249771b1eca61c801b