### PR TITLE
Implement generate-texture alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,10 +271,12 @@ MIT License
    curl http://localhost:3001/api/ai/api-keys/status
    
    # テクスチャ生成テスト
-   curl -X POST http://localhost:3001/api/ai/generate-texture \
-     -H "Content-Type: application/json" \
-     -d '{"prompt": "brick wall texture"}'
-   ```
+  curl -X POST http://localhost:3001/api/ai/generate-texture \
+    -H "Content-Type: application/json" \
+    -d '{"prompt": "brick wall texture"}'
+  ```
+
+`/generate-texture` は旧エンドポイント `/generate-wall-floor` のエイリアスです。
 
 ### ⚠️ 現在のエラー解決方法
 

--- a/backend/src/routes/ai/texture-generation.ts
+++ b/backend/src/routes/ai/texture-generation.ts
@@ -57,7 +57,7 @@ function selectTextureUrl(type: 'wall' | 'floor', material: string): string {
  * 壁・床テクスチャ生成エンドポイント
  * 現在は高品質モックテクスチャを使用（AI API統合は将来実装）
  */
-router.post('/generate-wall-floor', async (req, res) => {
+async function generateTextureHandler(req: express.Request, res: express.Response) {
   try {
     const { type, material, size = { width: 10, height: 5, depth: 0.2 } } = req.body;
     
@@ -109,6 +109,9 @@ router.post('/generate-wall-floor', async (req, res) => {
     
     res.json(fallbackResult);
   }
-});
+}
+
+router.post('/generate-wall-floor', generateTextureHandler);
+router.post('/generate-texture', generateTextureHandler);
 
 export default router; 


### PR DESCRIPTION
## Summary
- create a reusable handler for texture generation
- add `/generate-texture` alias endpoint for backwards compatibility
- document new alias in README

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68411ca54ac48324959ddf5963b8ffbe