### PR TITLE
Add wall & floor customization

### DIFF
--- a/frontend/src/components/three/RoomBuilder.tsx
+++ b/frontend/src/components/three/RoomBuilder.tsx
@@ -19,7 +19,6 @@ import { useModelManager } from '../../hooks/useModelManager';
 import useAIModelGenerator from '../../hooks/useAIModelGenerator';
 
 // Types
-import type { RoomConfig } from '../../types/room';
 
 const RoomBuilder: React.FC = () => {
   const navigate = useNavigate();
@@ -224,11 +223,19 @@ const RoomBuilder: React.FC = () => {
           roomObjects={roomState.roomConfig.objects}
           editMode={roomState.editMode}
           showGrid={roomState.showGrid}
+          wallMaterial={roomState.roomConfig.wallMaterial}
+          floorMaterial={roomState.roomConfig.floorMaterial}
           onViewModeChange={roomState.setViewMode}
           onEditModeChange={roomState.setEditMode}
           onShowGridToggle={() => roomState.setShowGrid(!roomState.showGrid)}
           onObjectManagerOpen={() => roomState.setIsObjectManagerOpen(true)}
           onDeleteObject={roomState.deleteObject}
+          onWallMaterialChange={(material) =>
+            roomState.setRoomConfig(prev => ({ ...prev, wallMaterial: material }))
+          }
+          onFloorMaterialChange={(material) =>
+            roomState.setRoomConfig(prev => ({ ...prev, floorMaterial: material }))
+          }
         />
       )}
 

--- a/frontend/src/components/three/RoomEnvironment.tsx
+++ b/frontend/src/components/three/RoomEnvironment.tsx
@@ -238,7 +238,13 @@ export const RoomEnvironment: React.FC<RoomEnvironmentProps> = ({
       >
         <planeGeometry args={[20, 20]} />
         <meshStandardMaterial
-          color={config.floorMaterial === 'wood' ? '#DEB887' : '#D3D3D3'}
+          color={
+            config.floorMaterial === 'wood'
+              ? '#DEB887'
+              : config.floorMaterial === 'tile'
+                ? '#DCDCDC'
+                : '#D3D3D3'
+          }
           roughness={0.8}
           metalness={0.1}
         />
@@ -249,7 +255,13 @@ export const RoomEnvironment: React.FC<RoomEnvironmentProps> = ({
       <mesh position={[0, 2.5, -10]} castShadow receiveShadow>
         <boxGeometry args={[20, 5, 0.2]} />
         <meshStandardMaterial
-          color={config.wallMaterial === 'brick' ? '#B22222' : '#F5F5F5'}
+          color={
+            config.wallMaterial === 'brick'
+              ? '#B22222'
+              : config.wallMaterial === 'wood'
+                ? '#DEB887'
+                : '#F5F5F5'
+          }
           roughness={0.9}
         />
       </mesh>
@@ -258,7 +270,13 @@ export const RoomEnvironment: React.FC<RoomEnvironmentProps> = ({
       <mesh position={[-10, 2.5, 0]} rotation={[0, Math.PI / 2, 0]} castShadow receiveShadow>
         <boxGeometry args={[20, 5, 0.2]} />
         <meshStandardMaterial
-          color={config.wallMaterial === 'brick' ? '#B22222' : '#F5F5F5'}
+          color={
+            config.wallMaterial === 'brick'
+              ? '#B22222'
+              : config.wallMaterial === 'wood'
+                ? '#DEB887'
+                : '#F5F5F5'
+          }
           roughness={0.9}
         />
       </mesh>
@@ -267,7 +285,13 @@ export const RoomEnvironment: React.FC<RoomEnvironmentProps> = ({
       <mesh position={[10, 2.5, 0]} rotation={[0, -Math.PI / 2, 0]} castShadow receiveShadow>
         <boxGeometry args={[20, 5, 0.2]} />
         <meshStandardMaterial
-          color={config.wallMaterial === 'brick' ? '#B22222' : '#F5F5F5'}
+          color={
+            config.wallMaterial === 'brick'
+              ? '#B22222'
+              : config.wallMaterial === 'wood'
+                ? '#DEB887'
+                : '#F5F5F5'
+          }
           roughness={0.9}
         />
       </mesh>

--- a/frontend/src/components/three/ui/ControlPanel.tsx
+++ b/frontend/src/components/three/ui/ControlPanel.tsx
@@ -7,11 +7,15 @@ interface ControlPanelProps {
   roomObjects: RoomObject[];
   editMode: EditMode;
   showGrid: boolean;
+  wallMaterial: string;
+  floorMaterial: string;
   onViewModeChange: (mode: ViewMode) => void;
   onEditModeChange: (mode: EditMode) => void;
   onShowGridToggle: () => void;
   onObjectManagerOpen: () => void;
   onDeleteObject: (id: string) => void;
+  onWallMaterialChange: (material: string) => void;
+  onFloorMaterialChange: (material: string) => void;
 }
 
 export const ControlPanel: React.FC<ControlPanelProps> = ({
@@ -20,11 +24,15 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
   roomObjects,
   editMode,
   showGrid,
+  wallMaterial,
+  floorMaterial,
   onViewModeChange,
   onEditModeChange,
   onShowGridToggle,
   onObjectManagerOpen,
-  onDeleteObject
+  onDeleteObject,
+  onWallMaterialChange,
+  onFloorMaterialChange
 }) => {
   const selectedObject = selectedObjectId
     ? roomObjects.find(obj => obj.id === selectedObjectId)
@@ -68,10 +76,38 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
         </div>
       )}
 
-      {/* Object Count */}
-      <div className="mb-3 text-xs text-gray-300">
-        配置済み: {roomObjects.length} 個
-      </div>
+  {/* Object Count */}
+  <div className="mb-3 text-xs text-gray-300">
+    配置済み: {roomObjects.length} 個
+  </div>
+
+  {/* Environment Settings */}
+  <div className="mb-3 space-y-2">
+    <div>
+      <label className="block text-xs text-gray-300 mb-1">🧱 壁素材</label>
+      <select
+        value={wallMaterial}
+        onChange={(e) => onWallMaterialChange(e.target.value)}
+        className="w-full bg-gray-700 rounded text-xs px-2 py-1"
+      >
+        <option value="concrete">コンクリート</option>
+        <option value="brick">レンガ</option>
+        <option value="wood">木材</option>
+      </select>
+    </div>
+    <div>
+      <label className="block text-xs text-gray-300 mb-1">🪵 床素材</label>
+      <select
+        value={floorMaterial}
+        onChange={(e) => onFloorMaterialChange(e.target.value)}
+        className="w-full bg-gray-700 rounded text-xs px-2 py-1"
+      >
+        <option value="wood">木材</option>
+        <option value="tile">タイル</option>
+        <option value="concrete">コンクリート</option>
+      </select>
+    </div>
+  </div>
 
       {/* Quick Actions */}
       <div className="grid grid-cols-2 gap-2 mb-3">


### PR DESCRIPTION
## Summary
- allow customizing wall/floor material in control panel
- persist changes through RoomBuilder state
- update room environment colors for new materials

## Testing
- `npm install` in `frontend`
- `npm run build` *(fails: multiple existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843b14fbe608324930b1ea3290c796e